### PR TITLE
Switch to bitnami harbor

### DIFF
--- a/k8s/harbor/release.yaml
+++ b/k8s/harbor/release.yaml
@@ -11,26 +11,14 @@ spec:
   chart:
     spec:
       chart: harbor
-      version: 1.14.2
+      version: 2.10.2
       sourceRef:
         kind: HelmRepository
         name: harbor
-  # https://github.com/goharbor/harbor-helm/blob/main/values.yaml
+  # https://github.com/bitnami/charts/blob/main/bitnami/harbor/values.yaml
   values:
     externalURL: https://harbor.${cluster_domain}
-    harborAdminPassword: ${harbor_admin_password:=Harbor12345}
-    expose:
-      tls:
-        certSource: none
-      ingress:
-        hosts:
-          core: harbor.${cluster_domain}
-    persistence:
-      persistentVolumeClaim:
-        registry:
-          storageClass: ${harbor_storage_class:=}
-          accessMode: ${harbor_storage_access_mode:=ReadWriteOnce}
-        jobservice:
-          jobLog:
-            storageClass: ${harbor_storage_class:=}
-            accessMode: ${harbor_storage_access_mode:=ReadWriteOnce}
+    adminPassword: ${harbor_admin_password:=Harbor12345}
+    ingress:
+      core:
+        hostname: harbor.${cluster_domain}

--- a/k8s/harbor/repository.yaml
+++ b/k8s/harbor/repository.yaml
@@ -4,4 +4,5 @@ metadata:
   name: harbor
 spec:
   interval: 5m
-  url: https://helm.goharbor.io
+  url: oci://registry-1.docker.io/bitnamicharts
+  oci: true

--- a/k8s/harbor/repository.yaml
+++ b/k8s/harbor/repository.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   interval: 5m
   url: oci://registry-1.docker.io/bitnamicharts
-  oci: true
+  type: "oci"


### PR DESCRIPTION
This pull request updates the chart version of Harbor to 2.10.2 and switches the Helm repository to the Bitnami charts repository