### PR TITLE
Update kustomization.yaml to include new namespaces and releases

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -2,4 +2,4 @@ creation_rules:
   - path_regex: .sops.yaml
     encrypted_regex: ^(data|stringData)$
     age: |-
-      age120p4hfdjg4x84rcl50vaus77l6rvpqyfjw23lszcpa089asr4s4qrtytwd
+      age1u6vg8wles8yl43eztdwt2v4htzuv43e5p7vngwu9j0gqsvwuq5qs063vsf

--- a/k8s/cert-manager/README.md
+++ b/k8s/cert-manager/README.md
@@ -7,7 +7,9 @@ Cert Manager is a Kubernetes add-on to automate the management and issuance of T
 
 ## Post-build variables
 
-This OCI Artifact currently has no post-build variables to configure.
+| Variable       | Description               | Default | Required |
+| -------------- | ------------------------- | :-----: | :------: |
+| cluster_domain | The domain of the cluster |         |    ✓     |
 
 ## CRDs
 
@@ -21,9 +23,10 @@ This OCI Artifact provides CRDs. They must be deployed separately.
 
 This certificate is used to issue certificates for any cluster issuer. It must be configured with the correct issuer.
 
-| Variable            | Description                    | Default | Required |
-| ------------------- | ------------------------------ | :-----: | :------: |
-| cluster_domain      | The domain of the cluster      |         |    ✓     |
+| Variable                                   | Description                              | Default | Required |
+| ------------------------------------------ | ---------------------------------------- | :-----: | :------: |
+| cert_manager_replica_count                 | The number of replicas                   |    2    |    ✕     |
+| cert_manager_pod_disruption_budget_enabled | Enable/disable the pod disruption budget |  true   |    ✕     |
 
 #### Self-Signed Cluster Issuer
 

--- a/k8s/cert-manager/README.md
+++ b/k8s/cert-manager/README.md
@@ -24,7 +24,6 @@ This certificate is used to issue certificates for any cluster issuer. It must b
 | Variable            | Description                    | Default | Required |
 | ------------------- | ------------------------------ | :-----: | :------: |
 | cluster_domain      | The domain of the cluster      |         |    ✓     |
-| cluster_issuer_name | The name of the cluster issuer |         |    ✓     |
 
 #### Self-Signed Cluster Issuer
 

--- a/k8s/cert-manager/release.yaml
+++ b/k8s/cert-manager/release.yaml
@@ -16,3 +16,6 @@ spec:
     # This configures cert-manager to install and upgrade CRDs as part of the Helm release.
     # https://cert-manager.io/docs/installation/helm/#helm-installation
     installCRDs: true
+    replicaCount: ${cert_manager_replica_count:=2}
+    podDisruptionBudget:
+      enabled: ${cert_manager_pod_disruption_budget_enabled:=true}

--- a/k8s/cloudflared/release.yaml
+++ b/k8s/cloudflared/release.yaml
@@ -20,4 +20,4 @@ spec:
     cloudflare:
       tunnel_token: ${cloudflared_tunnel_token}
     image:
-      tag: 2024.5.0
+      tag: 2024.6.1

--- a/k8s/clusters/oci-artifacts/releases/cert-manager/selfsigned-cluster-issuer.yaml
+++ b/k8s/clusters/oci-artifacts/releases/cert-manager/selfsigned-cluster-issuer.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: selfsigned-cluster-issuer
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  dependsOn:
+    - name: cert-manager
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: cert-manager/cluster-issuers/selfsigned
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/cloudflared/cloudflared.yaml
+++ b/k8s/clusters/oci-artifacts/releases/cloudflared/cloudflared.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudflared
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: cloudflared
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: cloudflared
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/cloudflared/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/cloudflared/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager.yaml
   - namespace.yaml
-  - selfsigned-cluster-issuer.yaml
+  - cloudflared.yaml

--- a/k8s/clusters/oci-artifacts/releases/cloudflared/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/cloudflared/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudflared

--- a/k8s/clusters/oci-artifacts/releases/gha-runner-scale-set-controller/gha-runner-scale-set-controller.yaml
+++ b/k8s/clusters/oci-artifacts/releases/gha-runner-scale-set-controller/gha-runner-scale-set-controller.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gha-runner-scale-set-controller
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: gha-runner-scale-set-controller
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/gha-runner-scale-set-controller/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/gha-runner-scale-set-controller/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager.yaml
+  - gha-runner-scale-set-controller.yaml
   - namespace.yaml
-  - selfsigned-cluster-issuer.yaml

--- a/k8s/clusters/oci-artifacts/releases/gha-runner-scale-set-controller/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/gha-runner-scale-set-controller/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gha-runner-scale-set-controller

--- a/k8s/clusters/oci-artifacts/releases/goldilocks/goldilocks.yaml
+++ b/k8s/clusters/oci-artifacts/releases/goldilocks/goldilocks.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: goldilocks
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: goldilocks
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: goldilocks
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/goldilocks/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/goldilocks/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager.yaml
+  - goldilocks.yaml
   - namespace.yaml
-  - selfsigned-cluster-issuer.yaml

--- a/k8s/clusters/oci-artifacts/releases/goldilocks/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/goldilocks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: goldilocks

--- a/k8s/clusters/oci-artifacts/releases/helm-charts-oci-proxy/helm-charts-oci-proxy.yaml
+++ b/k8s/clusters/oci-artifacts/releases/helm-charts-oci-proxy/helm-charts-oci-proxy.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: helm-charts-oci-proxy
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: helm-charts-oci-proxy
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: helm-charts-oci-proxy
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/helm-charts-oci-proxy/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/helm-charts-oci-proxy/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager.yaml
+  - helm-charts-oci-proxy.yaml
   - namespace.yaml
-  - selfsigned-cluster-issuer.yaml

--- a/k8s/clusters/oci-artifacts/releases/helm-charts-oci-proxy/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/helm-charts-oci-proxy/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helm-charts-oci-proxy

--- a/k8s/clusters/oci-artifacts/releases/homepage/homepage.yaml
+++ b/k8s/clusters/oci-artifacts/releases/homepage/homepage.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: homepage
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: homepage
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: homepage
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/homepage/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/homepage/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager.yaml
+  - homepage.yaml
   - namespace.yaml
-  - selfsigned-cluster-issuer.yaml

--- a/k8s/clusters/oci-artifacts/releases/homepage/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/homepage/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homepage

--- a/k8s/clusters/oci-artifacts/releases/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
   - homepage
   - oauth2-proxy
   - plantuml
-  - pulumi-operator
+  # - pulumi-operator # Not supported on ARM64
   - reloader
   - traefik
 

--- a/k8s/clusters/oci-artifacts/releases/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - gha-runner-scale-set-controller
   - goldilocks
   - harbor
-  - helm-charts-oci-proxy
+  # - helm-charts-oci-proxy # Not supported on ARM64
   - homepage
   - oauth2-proxy
   - plantuml

--- a/k8s/clusters/oci-artifacts/releases/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/kustomization.yaml
@@ -2,21 +2,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cert-manager
+  - cloudflared
+  - gha-runner-scale-set-controller
+  - goldilocks
   - harbor
+  - helm-charts-oci-proxy
+  - homepage
   - oauth2-proxy
+  - plantuml
+  - pulumi-operator
   - reloader
   - traefik
-  # - ../../../cloudflared
   # - ../../../gha-runner-scale-set
-  # - ../../../goldilocks
-  # - ../../../helm-charts-oci-proxy
   # - ../../../homepage
   # - ../../../kubelet-serving-cert-approver
-  # - ../../../metrics-server
-  # - ../../../plantuml
-  # - ../../../pulumi-operator
-  # - ../../../reloader
-  # - configmaps/oauth2-proxy-configmap.yaml
   # # - ../../../longhorn # open-iscsi does not exist as a kernel module in the Default GitHub Runner images
 
 patches:

--- a/k8s/clusters/oci-artifacts/releases/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/kustomization.yaml
@@ -13,10 +13,6 @@ resources:
   - pulumi-operator
   - reloader
   - traefik
-  # - ../../../gha-runner-scale-set
-  # - ../../../homepage
-  # - ../../../kubelet-serving-cert-approver
-  # # - ../../../longhorn # open-iscsi does not exist as a kernel module in the Default GitHub Runner images
 
 patches:
   - patch: |

--- a/k8s/clusters/oci-artifacts/releases/metrics-server/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/metrics-server/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - metrics-server.yaml

--- a/k8s/clusters/oci-artifacts/releases/metrics-server/metrics-server.yaml
+++ b/k8s/clusters/oci-artifacts/releases/metrics-server/metrics-server.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: metrics-server
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: kube-system
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: metrics-server
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/plantuml/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/plantuml/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager.yaml
+  - plantuml.yaml
   - namespace.yaml
-  - selfsigned-cluster-issuer.yaml

--- a/k8s/clusters/oci-artifacts/releases/plantuml/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/plantuml/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: plantuml
+

--- a/k8s/clusters/oci-artifacts/releases/plantuml/plantuml.yaml
+++ b/k8s/clusters/oci-artifacts/releases/plantuml/plantuml.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: plantuml
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: plantuml
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: plantuml
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/pulumi-operator/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/pulumi-operator/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager.yaml
+  - pulumi-operator.yaml
   - namespace.yaml
-  - selfsigned-cluster-issuer.yaml

--- a/k8s/clusters/oci-artifacts/releases/pulumi-operator/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/pulumi-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pulumi-operator
+

--- a/k8s/clusters/oci-artifacts/releases/pulumi-operator/pulumi-operator.yaml
+++ b/k8s/clusters/oci-artifacts/releases/pulumi-operator/pulumi-operator.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: pulumi-operator
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: pulumi-operator
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: pulumi-operator
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/variables/variables-sensitive.sops.yaml
+++ b/k8s/clusters/oci-artifacts/variables/variables-sensitive.sops.yaml
@@ -6,27 +6,26 @@ metadata:
     name: variables-sensitive
     namespace: flux-system
 stringData:
-    cloudflared_tunnel_token: ENC[AES256_GCM,data:pJSFBUZEYh55zJzCzRk/46PMeNeqgbrkorkSTgETS4cl/+P/Brar9CIFcacR3cRrv2N1noRBtgkZbzPa4NxuswfRx2VJoswN7t6kobaDlbvPFMBMzCz92GuL3mrTJtAbnOeGL4kdfSKhI64tnEGBT4eYQZeassNoTKu75Z1Anz+zCkpAv437kwe/4rCB3/d0cZ2y70xnQlBAIBY8qKh6z0wTnH2vSctRFfVgMYV1oxDYrbZV2EqX9A==,iv:0k8K6RfdwTBTXJ1ZrqF3hHKiRKquPBHOkvFkMJfX/Ck=,tag:/9Q0biyzLVRhWaGffKoC3g==,type:str]
-    github_token: ENC[AES256_GCM,data:pzMy6NeOBeK7y9mJgB5ZyBniENis+a3aZy3suD8xl5gxx83Uewu5jg==,iv:R4yZehuvRNPhRiGA2g9+RoHY4rzs4r8mBfoaxcvDog0=,tag:wmPqc3kxyc4b5jdYOqzsZA==,type:str]
-    oauth2_proxy_client_secret: ENC[AES256_GCM,data:uoO5F+eXQMz+oNKOWu0eRg3rrfZmvPY+qPC+jVhkF2t5sD1QmYLZ7A==,iv:xAfMFUhBC8sUHTn3i/TbtY+X/aKXuJRL80tVJiEljjY=,tag:mF5T39HbHxfNywEUeplCYg==,type:str]
-    oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:LHRj8aTTepEBZTCpner3TbUOyxQLiwMpMFAMe6EAuGTrU26o2HY7/SyKihs=,iv:oaHRc5gTA6dhAFyp+fWXwwWRUfu+h9ON+MhV9yVrB1Q=,tag:pG38+ginZV2eKAclw3CrZg==,type:str]
+    cloudflared_tunnel_token: ENC[AES256_GCM,data:rKWMTJ4w3A8V9c3zfLWso8ye5/t5/l/Iv5dQwNuRZLLbxgIOpqxFzu5Q6IYbzBmOrd1mEdy3ibnmjyHY5cmdvL6BLmwRuCd4a0fKbNLP1URWYdx+on3F9g9zUwhedTakd1yKOsf8+tlb1vBOh0dpEeqq2xjCAq4O+yGB/G09xuJnovIaGqGL3tXCnPqX3p5BT9aQFAHyjUUGwEPtQ3olJ3vwEVCOgD0knpTsiOQqs3V7RnET0QMnDA==,iv:GwL8PUMCDB2mZgr9dCbYpSGrL+Pa7INWXE5AClkG1Zw=,tag:CC+PMYdWQ0LCFY5WmndFNA==,type:str]
+    oauth2_proxy_client_secret: ENC[AES256_GCM,data:LN0BvNuivI3qH807Cuf7l7fcQ7aYB5KfoGqZkyzJcEBSHiTl3kwOKQ==,iv:aImAIN5wQYPI9kqQf14g/EBgkw657fqieDBahpyLnRY=,tag:GMsr54A6FNeS1dul4tgy8g==,type:str]
+    oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:j8Vm4tcgmd/osGKuIe9pwrQvllFycfuCFTq+npWQUd+ws7wfbO/1vl7C098=,iv:4QmooeR2QTjQdSVIcFWmmsoVeFKEUL7VMRYuEQ/5zhs=,tag:UNYmwc4KsYBNce824xKm0A==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age:
-        - recipient: age120p4hfdjg4x84rcl50vaus77l6rvpqyfjw23lszcpa089asr4s4qrtytwd
+        - recipient: age1u6vg8wles8yl43eztdwt2v4htzuv43e5p7vngwu9j0gqsvwuq5qs063vsf
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2dGhiR3pvK1hNbWN4NDZ1
-            RzA4S0p2eEFhaHl5ZXZMS05iQzRMTXdqcVgwClQyeUdwUjh6RVp6NjFaQjQ3U3Qx
-            a2RoV2tMOXZNc3lyVnJtRWRlK29mMjQKLS0tIHB1UWVHTW01NmtjYzlVZFN6UHRD
-            dm5TamJ3eGlrV3pZYmJUZUNGNURLMGsKlp4BSFvfOHJ3ktY26qWR605TRob4Rd8q
-            3c9Lo7JbTFjfJ3J3mUTdrHcmPg/sVLNGezuklI5sw96JvhnY6RkBQg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3NFk5eGE5ZDNjcVdRQXBk
+            L0lnMGtidm1wK0pUOUZyNzNWMXRaemprT2g0CkY2ZGVQei9GTVdtUE82WUNEa3lC
+            ZVhkK01KVVhXQndlc2RYQ1M1TThNVFUKLS0tIDJhb2dxaTZuUkZ3bzhZdElkQnNR
+            dktvampqbndXczBIb0RaYlQ1d25CWHMKYX+JxdMG9wa0m7Q46/dWhZlcEcCYJLg1
+            duywLLGcRSO2lWOl5XyB4CT1abDV3oTgXIr4OeUwtnMnNP+ciDV3Mg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-05-14T20:25:48Z"
-    mac: ENC[AES256_GCM,data:Cu2WPJTzExoAWCpl90UQBuZE2nWHeVmC+Ft+91C17HqE/lU7ocpquqQkRAT9laiKYT4AqvPN2H8///yqujz36joYgs0+3Dc89SYdzjduyuQ4uBuWNVaC9INREQt8DH3YJrIYhKVmjO6h7HbZc+amnocfQIq1rvQCZEeNuQsgv9M=,iv:Q5tJuUUu/5pV77xLBpcgew7gbwx6Or3V4tZ13e/Fz90=,tag:zKjYyDbhWOtuLSCFTrKhcA==,type:str]
+    lastmodified: "2024-07-21T12:45:50Z"
+    mac: ENC[AES256_GCM,data:mILibK+Ufb+L/hq35JphUc0SkN48XVkzdlPEFeVJxto11MEfGEXLp4ztIH/slCYUzMEx94ksKf8Paon4aWzLsn5I/1Zgdg1eab4LT9Z5kYm4f+ZhRfHQ2h6lSESW5kJmC8YGXbcoCnw9sAEzh9ue9sRBP+6cR4x1vnJORtVAKLA=,iv:33b4PNivZk6crDJE0LwYuU7VVH/svRcN4tFUPF9Pcws=,tag:JLfn3OEc9LwFyvIZE8OG6Q==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1

--- a/k8s/clusters/oci-artifacts/variables/variables-sensitive.sops.yaml
+++ b/k8s/clusters/oci-artifacts/variables/variables-sensitive.sops.yaml
@@ -1,14 +1,12 @@
-# You need to encrypt this file with SOPS manually.
-# ksail sops --encrypt variables-sensitive.sops.yaml
 apiVersion: v1
 kind: Secret
 metadata:
     name: variables-sensitive
     namespace: flux-system
 stringData:
-    cloudflared_tunnel_token: ENC[AES256_GCM,data:rKWMTJ4w3A8V9c3zfLWso8ye5/t5/l/Iv5dQwNuRZLLbxgIOpqxFzu5Q6IYbzBmOrd1mEdy3ibnmjyHY5cmdvL6BLmwRuCd4a0fKbNLP1URWYdx+on3F9g9zUwhedTakd1yKOsf8+tlb1vBOh0dpEeqq2xjCAq4O+yGB/G09xuJnovIaGqGL3tXCnPqX3p5BT9aQFAHyjUUGwEPtQ3olJ3vwEVCOgD0knpTsiOQqs3V7RnET0QMnDA==,iv:GwL8PUMCDB2mZgr9dCbYpSGrL+Pa7INWXE5AClkG1Zw=,tag:CC+PMYdWQ0LCFY5WmndFNA==,type:str]
-    oauth2_proxy_client_secret: ENC[AES256_GCM,data:LN0BvNuivI3qH807Cuf7l7fcQ7aYB5KfoGqZkyzJcEBSHiTl3kwOKQ==,iv:aImAIN5wQYPI9kqQf14g/EBgkw657fqieDBahpyLnRY=,tag:GMsr54A6FNeS1dul4tgy8g==,type:str]
-    oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:j8Vm4tcgmd/osGKuIe9pwrQvllFycfuCFTq+npWQUd+ws7wfbO/1vl7C098=,iv:4QmooeR2QTjQdSVIcFWmmsoVeFKEUL7VMRYuEQ/5zhs=,tag:UNYmwc4KsYBNce824xKm0A==,type:str]
+    cloudflared_tunnel_token: ENC[AES256_GCM,data:T8uct6HNkG2+NytMD4eelAz8I3OPuMsEw9sY/mjUDJfBNzV40WJAP+8EsEWKU0GngN+eVKwcnhW+rj97XhZVihAT3+aByzkPQL7VcASnFCa9WDvKpiKUGfdINI0P9fbZkqJ+d/aCuoyG/FK57+DiGV28iw6uqcoD2VMVTYeqpRrM9nY4CKeCOTAy/pkRuXfVXQo750zeZDR+QDDodeangOhU4/nS4AIQO6NJINBq011VYsUeHYiIkw==,iv:hhglJ5IT1LKUdnCdCPrvqse5psk3i+BciFVMNkb+Dbc=,tag:AV8BweAdMdSW9EeVx9+Gfw==,type:str]
+    oauth2_proxy_client_secret: ENC[AES256_GCM,data:NVRZ3uKrkKa8NlxOu0l660SimWbbSx4Fai5NHdT0qp4+lkPCeA09+g==,iv:C5uRRiSdFnsmLq0an9DFu8+ocj56lZR1qJWHMluAZEw=,tag:66XX2KaAl0J6rAkWPgZz7A==,type:str]
+    oauth2_proxy_cookie_secret: ENC[AES256_GCM,data:EWtIulQNsHvBuMFsShPORLseAFJJcwqCkfv3cVhWQ7mNGSiXgC3K4q8E1w4=,iv:Mf24XjLqpet71N0y8dcmNkTpD385xTMiV1b4hMgNefM=,tag:piMtn3s9dEdwW2zxdZMv+w==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -18,14 +16,14 @@ sops:
         - recipient: age1u6vg8wles8yl43eztdwt2v4htzuv43e5p7vngwu9j0gqsvwuq5qs063vsf
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3NFk5eGE5ZDNjcVdRQXBk
-            L0lnMGtidm1wK0pUOUZyNzNWMXRaemprT2g0CkY2ZGVQei9GTVdtUE82WUNEa3lC
-            ZVhkK01KVVhXQndlc2RYQ1M1TThNVFUKLS0tIDJhb2dxaTZuUkZ3bzhZdElkQnNR
-            dktvampqbndXczBIb0RaYlQ1d25CWHMKYX+JxdMG9wa0m7Q46/dWhZlcEcCYJLg1
-            duywLLGcRSO2lWOl5XyB4CT1abDV3oTgXIr4OeUwtnMnNP+ciDV3Mg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUSDZFaXN6T3paQ2VndmVH
+            S2RlOVFsT1RnVGNBVmNENHFFSU9QeUJoc2djCkNMTlU0REx6Q0tLVmZVMkFZM2tY
+            ZnRQNmtzZ3RMTEVIQnNqVXJqRFJkTFkKLS0tIDllQzQ2YkRpNjJ1bFFRZ1BYcXpz
+            QTloV0dJNDBzUzA4aSt1THRyclBQWXcK0hc1xM0qocfoPGhDX1Cv8gqfcnH1aM/J
+            YmLfVmQ2ebYEZFE4/3RRYYe5HyDTXT/dryAg4h6ocUxWIs5nW0mFFw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-07-21T12:45:50Z"
-    mac: ENC[AES256_GCM,data:mILibK+Ufb+L/hq35JphUc0SkN48XVkzdlPEFeVJxto11MEfGEXLp4ztIH/slCYUzMEx94ksKf8Paon4aWzLsn5I/1Zgdg1eab4LT9Z5kYm4f+ZhRfHQ2h6lSESW5kJmC8YGXbcoCnw9sAEzh9ue9sRBP+6cR4x1vnJORtVAKLA=,iv:33b4PNivZk6crDJE0LwYuU7VVH/svRcN4tFUPF9Pcws=,tag:JLfn3OEc9LwFyvIZE8OG6Q==,type:str]
+    lastmodified: "2024-07-21T13:05:07Z"
+    mac: ENC[AES256_GCM,data:RR62WA/AHHIvh58a4yq39b+Z2IQmCdGD0ZAiRplxP79uj5kXaVl2avPko19jIrnJCwKxCUNx7OWjuAhR7LnveepDdqLg5OA0agStOkBS8fYpd2lj2+BLGq3CozL86Kill4HdDnO8/JALzQ8BIN22tBC2dephjtcC2ePLHSpd/g4=,iv:lxA/zlZyDobwMi61yAJBLegTOD2hBicGau1Ynfh1LcI=,tag:xpS1E0cLO5V0wPMxYvjMjg==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1

--- a/k8s/clusters/oci-artifacts/variables/variables.yaml
+++ b/k8s/clusters/oci-artifacts/variables/variables.yaml
@@ -5,7 +5,5 @@ metadata:
   namespace: flux-system
 data:
   cluster_domain: oci-artifacts.k8s.local
-  cluster_issuer_name: selfsigned-cluster-issuer
-  gha_runner_scale_set_url: https://github.com/devantler/homelab
   harbor_persistent_volume_access_mode: ReadWriteOnce
-  oauth2_proxy_client_id: Ov23liQ4UtmGpfwiYpSZ
+  oauth2_proxy_client_id: Ov23liTcHVh1sTXBMykh


### PR DESCRIPTION
This pull request updates the kustomization.yaml file to include new namespaces and releases. It adds the following namespaces: homepage, goldilocks, plantuml, cloudflared, pulumi-operator, helm-charts-oci-proxy, and gha-runner-scale-set-controller. It also includes new releases for the cloudflared image (tag: 2024.6.1).