### PR TITLE
Add k8sgpt-operator manifests and resources

### DIFF
--- a/k8s/clusters/oci-artifacts/releases/k8sgpt-operator/k8sgpt-operator.yaml
+++ b/k8s/clusters/oci-artifacts/releases/k8sgpt-operator/k8sgpt-operator.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: k8sgpt-operator
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: k8sgpt-operator
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: k8sgpt-operator
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/k8sgpt-operator/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/k8sgpt-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - k8sgpt-operator.yaml

--- a/k8s/clusters/oci-artifacts/releases/k8sgpt-operator/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/k8sgpt-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8sgpt-operator

--- a/k8s/k8sgpt-operator/README.md
+++ b/k8s/k8sgpt-operator/README.md
@@ -1,0 +1,47 @@
+# K8sGPT Operator
+
+A Kubernetes operator to enable SRE superpowers within a Kubernetes cluster. It allows creating custom resources to define the behaviour and scope of a managed K8sGPT workload. Analysis and outputs will also be configurable to enable integration into existing workflows.
+
+## Usage
+
+1. Install the operator
+2. Create and apply a K8sGPT custom resource
+
+```yaml
+apiVersion: core.k8sgpt.ai/v1alpha1
+kind: K8sGPT
+metadata:
+  name: k8sgpt-sample
+  namespace: k8sgpt-operator-system
+spec:
+  ai:
+    enabled: true
+    model: gpt-3.5-turbo
+    backend: openai
+    secret:
+      name: k8sgpt-sample-secret
+      key: openai-api-key
+    # anonymized: false
+    # language: english
+  noCache: false
+  repository: ghcr.io/k8sgpt-ai/k8sgpt
+  version: v0.3.8
+  #integrations:
+  # trivy:
+  #  enabled: true
+  #  namespace: trivy-system
+  # filters:
+  #   - Ingress
+  # sink:
+  #   type: slack
+  #   webhook: <webhook-url> # use the sink secret if you want to keep your webhook url private
+  #   secret:
+  #     name: slack-webhook
+  #     key: url
+  #extraOptions:
+  #   backstage:
+  #     enabled: true
+```
+
+> [!INFO]
+> You might need to add a secret to contain your API Key for the chosen AI backend.

--- a/k8s/k8sgpt-operator/kustomization.yaml
+++ b/k8s/k8sgpt-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: k8sgpt-operator
+resources:
+  - release.yaml
+  - repository.yaml

--- a/k8s/k8sgpt-operator/release.yaml
+++ b/k8s/k8sgpt-operator/release.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: k8sgpt-operator
+spec:
+  interval: 1m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: k8sgpt-operator
+      version: 0.1.7
+      sourceRef:
+        kind: HelmRepository
+        name: k8sgpt-operator
+  # https://github.com/k8sgpt-ai/k8sgpt-operator/blob/main/chart/operator/values.yaml
+  values: {}

--- a/k8s/k8sgpt-operator/repository.yaml
+++ b/k8s/k8sgpt-operator/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: k8sgpt-operator
+spec:
+  interval: 1m
+  url: https://charts.k8sgpt.ai/


### PR DESCRIPTION
This pull request adds the necessary manifests and resources for the k8sgpt-operator. The kustomization files and namespace definition are included, as well as the HelmRelease and HelmRepository configurations. The k8sgpt-operator allows for the creation of custom resources to define the behavior and scope of a managed K8sGPT workload within a Kubernetes cluster. Usage instructions and an example custom resource YAML are also provided in the patches.