### PR TITLE
Add ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This repository contains Kubernetes (K8s) manifests distributed as OCI Artifacts
 - [Longhorn](k8s/longhorn/README.md)
 - [Metrics Server](k8s/metrics-server/README.md)
 - [OAuth2 Proxy](k8s/oauth2-proxy/README.md)
+- [Ollama](k8s/ollama/README.md)
 - [PlantUML](k8s/plantuml/README.md)
 - [Pulumi Operator](k8s/pulumi-operator/README.md)
 - [Reloader](k8s/reloader/README.md)

--- a/k8s/clusters/oci-artifacts/releases/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - k8sgpt-operator
   - local-ai
   - oauth2-proxy
+  - ollama
   - plantuml
   - reloader
   - traefik

--- a/k8s/clusters/oci-artifacts/releases/ollama/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/ollama/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ollama.yaml
+  - namespace.yaml

--- a/k8s/clusters/oci-artifacts/releases/ollama/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/ollama/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ollama

--- a/k8s/clusters/oci-artifacts/releases/ollama/ollama.yaml
+++ b/k8s/clusters/oci-artifacts/releases/ollama/ollama.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ollama
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: ollama
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: ollama
+  prune: true
+  wait: true

--- a/k8s/ollama/README.md
+++ b/k8s/ollama/README.md
@@ -1,0 +1,10 @@
+# Ollama
+
+An AI model serving platform to help you get up and running with Llama 3.1, Mistral, Gemma 2, and other large language models.
+
+## Post-build variables
+
+| Variable                   | Description                   | Default | Required |
+| -------------------------- | ----------------------------- | ------- | -------- |
+| ollama_ingress_enabled     | Enable ingress for Ollama     | true    | ✕        |
+| ollama_persistence_enabled | Enable persistence for Ollama | false   | ✕        |

--- a/k8s/ollama/kustomization.yaml
+++ b/k8s/ollama/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ollama
+resources:
+  - release.yaml
+  - repository.yaml

--- a/k8s/ollama/release.yaml
+++ b/k8s/ollama/release.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ollama
+spec:
+  interval: 1m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: ollama
+      version: 0.52.0
+      sourceRef:
+        kind: HelmRepository
+        name: ollama
+  # https://github.com/otwld/ollama-helm/blob/main/values.yaml
+  values:
+    ingress:
+      enabled: ${ollama_ingress_enabled:=true}
+      hosts:
+        - host: ollama.${cluster_domain}
+          paths:
+            - path: /
+              pathType: Prefix
+    persistentVolume:
+      enabled: ${ollama_persistence_enabled:=false}

--- a/k8s/ollama/repository.yaml
+++ b/k8s/ollama/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ollama
+spec:
+  interval: 1m
+  url: https://otwld.github.io/ollama-helm/


### PR DESCRIPTION
This pull request adds the ollama component to the project. The ollama component is an AI model serving platform that helps with running Llama 3.1, Mistral, Gemma 2, and other large language models. It includes the necessary YAML files and configurations for deployment, including a Helm chart, a namespace, and a Helm repository. The pull request also includes a table of post-build variables that can be used to customize the deployment, such as enabling ingress and persistence.