### PR TITLE
Update Traefik auth middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ This repository contains Kubernetes (K8s) manifests distributed as OCI Artifacts
 - [Pulumi Operator](k8s/pulumi-operator/README.md)
 - [Reloader](k8s/reloader/README.md)
 - [Traefik](k8s/traefik/README.md)
+  - [Middleware - Basic Auth](k8s/traefik/middlewares/basic-auth/README.md)
+  - [Middleware - Forward Auth](k8s/traefik/middlewares/forward-auth/README.md)
 
 OCI Artifacts are a great way to distribute ready-to-use K8s manifests. It requires almost no lines of code to get services deployed, and together with Flux and Flux post-build variables it can be a great addition to Helm charts. In most cases deploying a service, will require a single line + setting some post-build variables. In more advanced scenarios it might require patching the OCI Artifact with Kustomize patches.
 

--- a/k8s/clusters/oci-artifacts/variables/variables.yaml
+++ b/k8s/clusters/oci-artifacts/variables/variables.yaml
@@ -8,6 +8,6 @@ data:
   harbor_persistent_volume_access_mode: ReadWriteOnce
   local_ai_persistence_access_mode: ReadWriteOnce
   oauth2_proxy_client_id: Ov23liTcHVh1sTXBMykh
-  traefik_basic_auth_users: dXNlcjokYXByMSRwZ3lTallKeiRoQVF2Z2QzcWZ4QTQuLy5wR1d6S0kxCgo=
+  traefik_basic_auth_user: dXNlcjokYXByMSRwZ3lTallKeiRoQVF2Z2QzcWZ4QTQuLy5wR1d6S0kxCgo=
   traefik_forward_auth_address: https://oauth2-proxy.oci-artifacts.k8s.local/
   traefik_forward_auth_ssl_host: oci-artifacts.k8s.local

--- a/k8s/clusters/oci-artifacts/variables/variables.yaml
+++ b/k8s/clusters/oci-artifacts/variables/variables.yaml
@@ -8,3 +8,6 @@ data:
   harbor_persistent_volume_access_mode: ReadWriteOnce
   local_ai_persistence_access_mode: ReadWriteOnce
   oauth2_proxy_client_id: Ov23liTcHVh1sTXBMykh
+  traefik_basic_auth_users: dXNlcjokYXByMSRwZ3lTallKeiRoQVF2Z2QzcWZ4QTQuLy5wR1d6S0kxCgo=
+  traefik_forward_auth_address: https://oauth2-proxy.oci-artifacts.k8s.local/
+  traefik_forward_auth_ssl_host: oci-artifacts.k8s.local

--- a/k8s/traefik/README.md
+++ b/k8s/traefik/README.md
@@ -19,3 +19,8 @@ Traefik is a reverse proxy and load balancer that routes incoming requests to th
 | cluster_domain                   | The domain of the cluster                                         |      ""      |    ✓     |
 | traefik_ingress_load_balancer_ip | The IP address of the load balancer                               |      ""      |    ✕     |
 | traefik_service_type             | The service to provide ingressing for (LoadBalancer or ClusterIP) | LoadBalancer |    ✕     |
+
+## Custom Resources
+
+- [Middleware - Basic Auth](middlewares/basic-auth/README.md)
+- [Middleware - Forward Auth](middlewares/rate-limit/README.md)

--- a/k8s/traefik/middlewares/basic-auth/README.md
+++ b/k8s/traefik/middlewares/basic-auth/README.md
@@ -1,0 +1,15 @@
+# Traefik Middleware - Basic Auth
+
+This middleware adds basic authentication to requests.
+
+- [Documentation](https://doc.traefik.io/traefik/middlewares/http/basicauth/)
+
+## Dependencies
+
+- [Traefik](../../README.md)
+
+## Post-build variables
+
+| Variable                | Description                                    | Default | Required |
+| ----------------------- | ---------------------------------------------- | :-----: | :------: |
+| traefik_basic_auth_user | `htpasswd -nb user password \| openssl base64` |   ""    |    ✓     |

--- a/k8s/traefik/middlewares/basic-auth/traefik-basic-auth-secret.yaml
+++ b/k8s/traefik/middlewares/basic-auth/traefik-basic-auth-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: traefik-basic-auth-secret
+  namespace: traefik
+stringData:
+  users: |2
+    ${traefik_basic_auth_user}

--- a/k8s/traefik/middlewares/basic-auth/traefik-basic-auth.yaml
+++ b/k8s/traefik/middlewares/basic-auth/traefik-basic-auth.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: traefik
 spec:
   basicAuth:
-    secret: basic-auth
-
+    secret: traefik-basic-auth-secret

--- a/k8s/traefik/middlewares/forward-auth/README.md
+++ b/k8s/traefik/middlewares/forward-auth/README.md
@@ -1,0 +1,17 @@
+# Traefik Middleware - Forward Auth
+
+This middleware adds forward authentication to requests.
+
+- [Documentation](https://doc.traefik.io/traefik/middlewares/http/forwardauth/)
+
+## Dependencies
+
+- [Traefik](../../README.md)
+
+## Post-build variables
+
+| Variable                                      | Description                                     | Default | Required |
+| --------------------------------------------- | ----------------------------------------------- | :-----: | :------: |
+| traefik_forward_auth_address                  | The address of the forward auth service         |   ""    |    ✓     |
+| traefik_forward_auth_ssl_host                 | The host of the forward auth service            |   ""    |    ✓     |
+| traefik_forward_auth_tls_insecure_skip_verify | Whether to skip verification of the certificate |  true   |    ✕     |

--- a/k8s/traefik/middlewares/forward-auth/traefik-auth-headers.yaml
+++ b/k8s/traefik/middlewares/forward-auth/traefik-auth-headers.yaml
@@ -10,7 +10,7 @@ spec:
     browserXssFilter: true
     contentTypeNosniff: true
     forceSTSHeader: true
-    sslHost: ${cluster_domain}
+    sslHost: ${traefik_forward_auth_ssl_host}
     stsIncludeSubdomains: true
     stsPreload: true
     frameDeny: true

--- a/k8s/traefik/middlewares/forward-auth/traefik-forward-auth.yaml
+++ b/k8s/traefik/middlewares/forward-auth/traefik-forward-auth.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: traefik
 spec:
   forwardAuth:
-    address: https://oauth2-proxy.${cluster_domain}/
+    address: ${traefik_forward_auth_address}
     trustForwardHeader: true
     authResponseHeaders:
       - X-Auth-Request-Access-Token


### PR DESCRIPTION
This pull request updates the Traefik auth middlewares. It adds basic authentication to requests using the Basic Auth middleware and forward authentication to requests using the Forward Auth middleware. The Basic Auth middleware requires the `traefik_basic_auth_user` variable to be set, which is base64-encoded username and password. The Forward Auth middleware requires the `traefik_forward_auth_address` and `traefik_forward_auth_ssl_host` variables to be set, which specify the address and host of the forward auth service. The changes also include the creation of a secret `traefik-basic-auth-secret` that contains the basic auth user. Documentation links for both middlewares are provided.