### PR TITLE
Update Harbor OCI Artifact documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This repository contains Kubernetes (K8s) manifests distributed as OCI Artifacts
 - [Ollama](k8s/ollama/README.md)
 - [PlantUML](k8s/plantuml/README.md)
 - [Pulumi Operator](k8s/pulumi-operator/README.md)
-  - [Programs - Harbor Proxy Program](k8s/pulumi-operator/programs/harbor-proxy-program/README.md)
+  - [Program - Harbor Proxy Program](k8s/pulumi-operator/programs/harbor-proxy-program/README.md)
 - [Reloader](k8s/reloader/README.md)
 - [Traefik](k8s/traefik/README.md)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <summary>Show/hide folder structure</summary>
 
 <!-- readme-tree start -->
+
 ```
 .
 ├── .github
@@ -60,6 +61,7 @@
 
 51 directories
 ```
+
 <!-- readme-tree end -->
 
 </details>
@@ -73,15 +75,16 @@ This repository contains Kubernetes (K8s) manifests distributed as OCI Artifacts
 - [Harbor](k8s/harbor/README.md)
 - [Helm Charts OCI Proxy](k8s/helm-charts-oci-proxy/README.md)
 - [Homepage](k8s/homepage/README.md)
-- [LocalAI](k8s/local-ai/README.md)
-- [Kubelet Serving Cert Approver](k8s/kubelet-serving-cert-approver/README.md)
 - [K8sGPT Operator](k8s/k8sgpt-operator/README.md)
+- [Kubelet Serving Cert Approver](k8s/kubelet-serving-cert-approver/README.md)
+- [LocalAI](k8s/local-ai/README.md)
 - [Longhorn](k8s/longhorn/README.md)
 - [Metrics Server](k8s/metrics-server/README.md)
 - [OAuth2 Proxy](k8s/oauth2-proxy/README.md)
 - [Ollama](k8s/ollama/README.md)
 - [PlantUML](k8s/plantuml/README.md)
 - [Pulumi Operator](k8s/pulumi-operator/README.md)
+  - [Programs - Harbor Proxy Program](k8s/pulumi-operator/programs/harbor-proxy-program/README.md)
 - [Reloader](k8s/reloader/README.md)
 - [Traefik](k8s/traefik/README.md)
 

--- a/k8s/pulumi-operator/README.md
+++ b/k8s/pulumi-operator/README.md
@@ -2,4 +2,9 @@
 
 Pulumi Operator is a Kubernetes operator that manages and runs Pulumi programs and stacks.
 
-- [Documentation](https://www.pulumi.com/docs/using-pulumi/continuous-delivery/pulumi-kubernetes-operator/) -[Helm Chart](https://github.com/pulumi/pulumi-kubernetes-operator/tree/master/deploy/helm/pulumi-operator)
+- [Documentation](https://www.pulumi.com/docs/using-pulumi/continuous-delivery/pulumi-kubernetes-operator/)
+- [Helm Chart](https://github.com/pulumi/pulumi-kubernetes-operator/tree/master/deploy/helm/pulumi-operator)
+
+## Custom Resources
+
+- [Harbor Proxy Program](programs/harbor-proxy-program/README.md)

--- a/k8s/pulumi-operator/programs/harbor-proxy-program/README.md
+++ b/k8s/pulumi-operator/programs/harbor-proxy-program/README.md
@@ -1,0 +1,37 @@
+# Programs - Harbor Proxy Program
+
+This program is a Pulumi program and stack that configures a Harbor instance to be able to act as a pull-through cache and proxy for bothe docker images and Helm charts.
+
+It proxies the following registries:
+
+- `docker.io`
+- `ghcr.io`
+- `gcr.io`
+- `registry.k8s.io`
+- `quay.io`
+- `mcr.microsoft.com`
+
+To learn more about configuring the program and stack, visit the following:
+
+- [Documentation](https://www.pulumi.com/registry/packages/harbor/)
+
+## Dependencies
+
+- [Pulumi Operator](../../README.md)
+- [Harbor](../../../harbor/README.md)
+
+## Post-build variables
+
+| Variable                        | Description                                | Default                        | Required |
+| ------------------------------- | ------------------------------------------ | ------------------------------ | -------- |
+| harbor_docker_proxy_endpoint    | The endpoint of the Harbor Docker proxy    | <https://registry-1.docker.io> | ✕        |
+| harbor_github_proxy_endpoint    | The endpoint of the Harbor GitHub proxy    | <https://ghcr.io>              | ✕        |
+| harbor_google_proxy_endpoint    | The endpoint of the Harbor Google proxy    | <https://gcr.io>               | ✕        |
+| harbor_k8s_proxy_endpoint       | The endpoint of the Harbor K8s proxy       | <https://registry.k8s.io>      | ✕        |
+| harbor_quay_proxy_endpoint      | The endpoint of the Harbor Quay proxy      | <https://quay.io>              | ✕        |
+| harbor_microsoft_proxy_endpoint | The endpoint of the Harbor Microsoft proxy | <https://mcr.microsoft.com>    | ✕        |
+| pulumi_backend                  | The Pulumi backend to use                  | file:///pulumi-backend         | ✕        |
+| harbor_url                      | The URL of the Harbor instance             | <http://harbor-core.harbor>    | ✕        |
+| harbor_username                 | The username of the Harbor instance        | admin                          | ✕        |
+| harbor_password                 | The password of the Harbor instance        | Harbor12345                    | ✕        |
+| harbor_insecure                 | Whether to skip TLS verification           | false                          | ✕        |

--- a/k8s/pulumi-operator/programs/harbor-proxy-program/README.md
+++ b/k8s/pulumi-operator/programs/harbor-proxy-program/README.md
@@ -1,4 +1,4 @@
-# Programs - Harbor Proxy Program
+# Pulumi Operator Program - Harbor Proxy Program
 
 This program is a Pulumi program and stack that configures a Harbor instance to be able to act as a pull-through cache and proxy for bothe docker images and Helm charts.
 

--- a/k8s/pulumi-operator/programs/harbor-proxy-program/program.yaml
+++ b/k8s/pulumi-operator/programs/harbor-proxy-program/program.yaml
@@ -4,7 +4,7 @@
 apiVersion: pulumi.com/v1
 kind: Program
 metadata:
-  name: harbor-pulumi-program
+  name: harbor-proxy-program
   namespace: pulumi-operator
 program:
   resources:

--- a/k8s/pulumi-operator/programs/harbor-proxy-program/stack.yaml
+++ b/k8s/pulumi-operator/programs/harbor-proxy-program/stack.yaml
@@ -1,11 +1,11 @@
 apiVersion: pulumi.com/v1
 kind: Stack
 metadata:
-  name: harbor-pulumi-stack
+  name: harbor-proxy-stack
   namespace: pulumi-operator
 spec:
-  stack: harbor-pulumi-stack
-  backend: ${pulumi_backend:=file://}${pulumi_backend_path:=/pulumi-backend}
+  stack: harbor-proxy-stack
+  backend: ${pulumi_backend:=file:///pulumi-backend}
   programRef:
     name: harbor-pulumi-program
   envRefs:
@@ -17,5 +17,5 @@ spec:
   config:
     harbor:url: ${harbor_url:=http://harbor-core.harbor}
     harbor:username: ${harbor_username:=admin}
-    harbor:password: ${harbor_admin_password:=Harbor12345}
+    harbor:password: ${harbor_password:=Harbor12345}
     harbor:insecure: ${harbor_insecure:="false"}


### PR DESCRIPTION
This pull request updates the documentation for the Harbor OCI Artifact. It includes changes to the README file, adding information about the Harbor Proxy Program and its dependencies. The program acts as a pull-through cache and proxy for various registries, such as docker.io, ghcr.io, gcr.io, registry.k8s.io, quay.io, and mcr.microsoft.com. The pull request also includes updates to the Pulumi Operator stack and program files, renaming them to reflect the changes made.