### PR TITLE
Add Cluster API Operator resources and configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 
 This repository contains Kubernetes (K8s) manifests distributed as OCI Artifacts.
 
+- [Cluster API Operator](k8s/capi-operator/README.md)
 - [Cert Manager](k8s/cert-manager/README.md)
 - [Cloudflared](k8s/cloudflared/README.md)
 - [GitHub Actions Runner Scale Set](k8s/gha-runner-scale-set/README.md)

--- a/k8s/capi-operator/README.md
+++ b/k8s/capi-operator/README.md
@@ -1,0 +1,6 @@
+# Cluster API Operator
+
+a Kubernetes Operator designed to empower cluster administrators to handle the lifecycle of Cluster API providers within a management cluster using a declarative approach. It aims to improve user experience in deploying and managing Cluster API, making it easier to handle day-to-day tasks and automate workflows with GitOps.
+
+- [Documentation](https://cluster-api-operator.sigs.k8s.io)
+- [Helm Chart](https://cluster-api-operator.sigs.k8s.io/02_installation/04_helm-chart-installation)

--- a/k8s/capi-operator/kustomization.yaml
+++ b/k8s/capi-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: capi-operator-system
+resources:
+  - release.yaml
+  - repository.yaml

--- a/k8s/capi-operator/release.yaml
+++ b/k8s/capi-operator/release.yaml
@@ -19,5 +19,4 @@ spec:
         kind: HelmRepository
         name: capi-operator
   # https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml
-  values:
-    addon: helm
+  values: {}

--- a/k8s/capi-operator/release.yaml
+++ b/k8s/capi-operator/release.yaml
@@ -4,6 +4,9 @@ metadata:
   name: capi-operator
 spec:
   interval: 1m
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
   install:
     crds: CreateReplace
   upgrade:

--- a/k8s/capi-operator/release.yaml
+++ b/k8s/capi-operator/release.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: capi-operator
+spec:
+  interval: 1m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: cluster-api-operator
+      version: v0.12.0
+      sourceRef:
+        kind: HelmRepository
+        name: capi-operator
+  # https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml
+  values: {}

--- a/k8s/capi-operator/release.yaml
+++ b/k8s/capi-operator/release.yaml
@@ -19,4 +19,5 @@ spec:
         kind: HelmRepository
         name: capi-operator
   # https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/hack/charts/cluster-api-operator/values.yaml
-  values: {}
+  values:
+    addon: helm

--- a/k8s/capi-operator/repository.yaml
+++ b/k8s/capi-operator/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: capi-operator
+spec:
+  interval: 1m
+  url: https://kubernetes-sigs.github.io/cluster-api-operator

--- a/k8s/clusters/oci-artifacts/releases/capi-operator/capi-operator.yaml
+++ b/k8s/clusters/oci-artifacts/releases/capi-operator/capi-operator.yaml
@@ -10,7 +10,7 @@ spec:
   interval: 1m
   dependsOn:
     - name: cert-manager
-  targetNamespace: capi-operator
+  targetNamespace: capi-operator-system
   sourceRef:
     kind: OCIRepository
     name: flux-system

--- a/k8s/clusters/oci-artifacts/releases/capi-operator/capi-operator.yaml
+++ b/k8s/clusters/oci-artifacts/releases/capi-operator/capi-operator.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capi-operator
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: capi-operator
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: capi-operator
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/capi-operator/capi-operator.yaml
+++ b/k8s/clusters/oci-artifacts/releases/capi-operator/capi-operator.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/post-build-variables: enabled
 spec:
   interval: 1m
+  dependsOn:
+    - name: cert-manager
   targetNamespace: capi-operator
   sourceRef:
     kind: OCIRepository

--- a/k8s/clusters/oci-artifacts/releases/capi-operator/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/capi-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - capi-operator.yaml
+  - namespace.yaml

--- a/k8s/clusters/oci-artifacts/releases/capi-operator/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/capi-operator/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: capi-operator
+  name: capi-operator-system

--- a/k8s/clusters/oci-artifacts/releases/capi-operator/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/capi-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-operator

--- a/k8s/clusters/oci-artifacts/releases/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - capi-operator
   - cert-manager
   - cloudflared
   - gha-runner-scale-set-controller


### PR DESCRIPTION
This pull request adds the necessary resources and configurations for the Cluster API Operator. The Cluster API Operator is a Kubernetes Operator designed to empower cluster administrators to handle the lifecycle of Cluster API providers within a management cluster using a declarative approach. It aims to improve user experience in deploying and managing Cluster API, making it easier to handle day-to-day tasks and automate workflows with GitOps. The changes include adding documentation and a Helm chart for the Cluster API Operator, as well as updating the necessary YAML files for installation and configuration.