### PR TITLE
Add FleetDM

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This repository contains the following OCI Artifacts:
   - [Cluster Issuer - Cloudflare LetsEncrypt](k8s/cert-manager/cluster-issuers/cloudflare-letsencrypt/README.md)
   - [Cluster Issuer - Self-Signed](k8s/cert-manager/cluster-issuers/selfsigned/README.md)
 - [Cloudflared](k8s/cloudflared/README.md)
+- [FleetDM](k8s/fleetdm/README.md)
 - [GitHub Actions Runner Scale Set](k8s/gha-runner-scale-set/README.md)
 - [Goldilocks](k8s/goldilocks/README.md)
 - [Harbor](k8s/harbor/README.md)

--- a/k8s/clusters/oci-artifacts/releases/fleetdm/fleetdm.yaml
+++ b/k8s/clusters/oci-artifacts/releases/fleetdm/fleetdm.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: fleetdm
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/sops: enabled
+    app.kubernetes.io/post-build-variables: enabled
+spec:
+  interval: 1m
+  targetNamespace: fleetdm
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+  path: fleetdm
+  prune: true
+  wait: true

--- a/k8s/clusters/oci-artifacts/releases/fleetdm/kustomization.yaml
+++ b/k8s/clusters/oci-artifacts/releases/fleetdm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - fleetdm.yaml
+  - namespace.yaml

--- a/k8s/clusters/oci-artifacts/releases/fleetdm/namespace.yaml
+++ b/k8s/clusters/oci-artifacts/releases/fleetdm/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fleetdm

--- a/k8s/fleetdm/README.md
+++ b/k8s/fleetdm/README.md
@@ -1,0 +1,6 @@
+# Fleet Device Management
+
+Fleet Device Management is a free and open source device management solution for teams of any size. It supports all major operating systems, while still allowing low-level access to OS-specific features.
+
+- [Documentation](https://fleetdm.com/docs/)
+- [Helm Chart](https://github.com/fleetdm/fleet/tree/main/charts/fleet)

--- a/k8s/fleetdm/kustomization.yaml
+++ b/k8s/fleetdm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml
+  - repository.yaml

--- a/k8s/fleetdm/release.yaml
+++ b/k8s/fleetdm/release.yaml
@@ -1,0 +1,29 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fleetdm
+  namespace: fleetdm
+spec:
+  interval: 1m
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  chart:
+    spec:
+      chart: fleetdm
+      version: 0.9.3
+      sourceRef:
+        kind: HelmRepository
+        name: fleetdm
+  # https://github.com/fleetdm/fleet/blob/main/charts/fleet/values.yaml
+  values:
+    resources: {}
+    hostName: fleetdm.${cluster_domain}
+    ingress:
+      enabled: true
+      hosts:
+        - host: fleetdm.${cluster_domain}
+          paths:
+            - path: /
+              pathType: ImplementationSpecific

--- a/k8s/fleetdm/repository.yaml
+++ b/k8s/fleetdm/repository.yaml
@@ -1,0 +1,7 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: fleetdm
+  namespace: fleetdm
+spec:
+  url: https://fleetdm.github.io/fleet/charts


### PR DESCRIPTION
This pull request adds FleetDM to the repository. FleetDM is a free and open source device management solution that supports all major operating systems and allows low-level access to OS-specific features. It includes the necessary Kubernetes manifests and Helm charts to deploy FleetDM in the cluster. For more information, please refer to the [FleetDM documentation](https://fleetdm.com/docs/) and the [FleetDM Helm Chart](https://github.com/fleetdm/fleet/tree/main/charts/fleet).